### PR TITLE
Update to 1.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,21 +2,21 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
-minecraft_version=1.20.5
-loader_version=0.15.10
+minecraft_version=1.21
+loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.5
+mod_version=1.6
 maven_group=me.wesley1808
 archives_base_name=advancedchat
 
 # API dependencies
-fabric_version=0.97.6+1.20.5
-placeholder_api_version=2.4.0-pre.1+1.20.5
-playerdata_api_version=0.5.0+1.20.5
-predicate_api_version=0.4.0+1.20.5
+fabric_version=0.100.1+1.21
+placeholder_api_version=2.4.0-pre.2+1.21
+playerdata_api_version=0.6.0+1.21
+predicate_api_version=0.5.1+1.21
 permission_api_version=0.3.1
 
 # Other dependencies
-styledchat_version=2.5.0+1.20.5
-vanish_version=1.5.3+1.20.5
+styledchat_version=2.6.0+1.21
+vanish_version=1.5.5+1.21

--- a/src/main/java/me/wesley1808/advancedchat/impl/predicates/ChannelPredicate.java
+++ b/src/main/java/me/wesley1808/advancedchat/impl/predicates/ChannelPredicate.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class ChannelPredicate extends AbstractPredicate {
     private static final String GLOBAL_CHANNEL = "global";
-    public static final ResourceLocation ID = new ResourceLocation("advancedchat", "channel");
+    public static final ResourceLocation ID = ResourceLocation.tryBuild("advancedchat", "channel");
     public static final MapCodec<ChannelPredicate> CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(Codec.STRING.fieldOf("channel").forGetter(ChannelPredicate::channel))
             .apply(instance, ChannelPredicate::new)

--- a/src/main/java/me/wesley1808/advancedchat/impl/predicates/CustomDistancePredicate.java
+++ b/src/main/java/me/wesley1808/advancedchat/impl/predicates/CustomDistancePredicate.java
@@ -10,7 +10,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.phys.Vec3;
 
 public class CustomDistancePredicate extends AbstractChatPredicate {
-    public static final ResourceLocation ID = new ResourceLocation("advancedchat", "distance");
+    public static final ResourceLocation ID = ResourceLocation.tryBuild("advancedchat", "distance");
     public static final MapCodec<CustomDistancePredicate> CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(DistancePredicate.CODEC.fieldOf("value").forGetter((inst) -> inst.predicate))
             .apply(instance, CustomDistancePredicate::new)

--- a/src/main/java/me/wesley1808/advancedchat/impl/utils/PlaceHolders.java
+++ b/src/main/java/me/wesley1808/advancedchat/impl/utils/PlaceHolders.java
@@ -23,7 +23,7 @@ public class PlaceHolders {
     }
 
     private static void register(String name, PlaceholderHandler handler) {
-        Placeholders.register(new ResourceLocation("advancedchat", name), handler);
+        Placeholders.register(ResourceLocation.tryBuild("advancedchat", name), handler);
     }
 }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.15.0",
-    "minecraft": ">=1.20.5-"
+    "minecraft": ">=1.21-"
   },
   "suggests": {
     "styledchat": "*"


### PR DESCRIPTION
I've updated `gradle.properties` to use the most recent versions available for 1.21 and I replaced `new ResourceLocation` calls with `ResourceLocation.tryBuild`, as the `ResourceLocation` constructor is now private. I also updated `fabric.mod.json` to use Minecraft 1.21 in the dependencies.

Mod builds fine, and from some quick testing everything seems to work okay. Could maybe use some more testing, but I don't expect much has broken with 1.21 as the update didn't contain much changes regarding chat.