### PR TITLE
introduce new player compare predicate

### DIFF
--- a/src/main/java/me/wesley1808/advancedchat/impl/predicates/PlayerPredicateCompare.java
+++ b/src/main/java/me/wesley1808/advancedchat/impl/predicates/PlayerPredicateCompare.java
@@ -1,0 +1,45 @@
+package me.wesley1808.advancedchat.impl.predicates;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import eu.pb4.predicate.api.MinecraftPredicate;
+import eu.pb4.predicate.api.PredicateContext;
+import eu.pb4.predicate.api.PredicateResult;
+import eu.pb4.predicate.impl.predicates.GenericObject;
+import me.wesley1808.advancedchat.api.AbstractChatPredicate;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Objects;
+
+public class PlayerPredicateCompare extends AbstractChatPredicate {
+    public static final ResourceLocation ID = ResourceLocation.tryBuild("advancedchat", "compare");
+    public static final MapCodec<PlayerPredicateCompare> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            GenericObject.CODEC.fieldOf("compare_predicate").forGetter((x) -> x.predicateObj)
+    ).apply(instance, PlayerPredicateCompare::new));
+
+    private final Object predicateObj;
+    private final MinecraftPredicate predicate;
+
+    public PlayerPredicateCompare(Object predicateObj) {
+        super(ID, CODEC);
+
+        this.predicateObj = predicateObj;
+        this.predicate = GenericObject.toPredicate(predicateObj);
+    }
+
+    @Override
+    public PredicateResult<?> test(ServerPlayer sender, ServerPlayer target) {
+        var val1 = this.predicate.test(PredicateContext.of(sender));
+        var val2 = this.predicate.test(PredicateContext.of(target));
+
+        if (val1.value() instanceof Component text && val2.value() instanceof String string) {
+            return PredicateResult.ofBoolean(text.getString().equals(string));
+        } else if (val2.value() instanceof Component text && val1.value() instanceof String string) {
+            return PredicateResult.ofBoolean(text.getString().equals(string));
+        } else {
+            return PredicateResult.ofBoolean(val1.success() == val2.success() && Objects.equals(val1.value(), val2.value()));
+        }
+    }
+}

--- a/src/main/java/me/wesley1808/advancedchat/impl/predicates/Predicates.java
+++ b/src/main/java/me/wesley1808/advancedchat/impl/predicates/Predicates.java
@@ -7,5 +7,6 @@ public class Predicates {
     public static void register() {
         PredicateRegistry.register(CustomDistancePredicate.ID, CustomDistancePredicate.CODEC);
         PredicateRegistry.register(ChannelPredicate.ID, ChannelPredicate.CODEC);
+        PredicateRegistry.register(PlayerPredicateCompare.ID, PlayerPredicateCompare.CODEC);
     }
 }


### PR DESCRIPTION
Hey there, first off. love the plugin, it's quite dynamic and powerful!

In the spirit of making it even better, I have came up with a new type of predicate that allows admins to specify a certain predicate that gets ran against source and target, and if they both return the same thing, the target is allowed to receive the message, this will allow for even more dynamic setups, like dynamic guild chats (or world chat written a different way). Below is an example: 

```json
  "channels": [
    {
      "name": "world",
      "enabled": true,
      "isStaff": false,
      "actionbar": "<dark_aqua>Chat Mode: <green>%world:name%",
      "prefix": "<dark_gray>[<aqua>%world:name%</aqua>]</dark_gray> ",
      "canSee": {
        "type": "advancedchat:compare",
        "compare_predicate": {
          "type": "placeholder",
          "placeholder": "world:name",
          "raw": false
        }
      }
    }
  ]
```

The compare predicate can be whatever predicate there is, whether builtin or mod provided, making this expression quite flexible. You could also use this to compare LP meta between users.

I tried this locally with 2 clients and it worked quite well.